### PR TITLE
Add 'exec-path' to environment variable when spawning the LSP server.

### DIFF
--- a/lspce.el
+++ b/lspce.el
@@ -612,7 +612,7 @@ Return value of `body', or nil if interrupted."
     (lspce--debug "lspce--connect initialize-params: %s" (json-encode initialize-params))
 
     (setq lspce--latest-tick (lspce--current-tick))
-    (setq response-str (lspce-module-connect root-uri lsp-type server-cmd server-args (json-encode (lspce--make-request "initialize" initialize-params lspce--latest-tick)) lspce-connect-server-timeout))
+    (setq response-str (lspce-module-connect root-uri lsp-type server-cmd server-args (json-encode (lspce--make-request "initialize" initialize-params lspce--latest-tick)) lspce-connect-server-timeout) (mapconcat 'identity exec-path ":"))
     (lspce--debug "lspce--connect response: %s" response-str)
 
     response-str))

--- a/lspce.el
+++ b/lspce.el
@@ -612,7 +612,7 @@ Return value of `body', or nil if interrupted."
     (lspce--debug "lspce--connect initialize-params: %s" (json-encode initialize-params))
 
     (setq lspce--latest-tick (lspce--current-tick))
-    (setq response-str (lspce-module-connect root-uri lsp-type server-cmd server-args (json-encode (lspce--make-request "initialize" initialize-params lspce--latest-tick)) lspce-connect-server-timeout) (mapconcat 'identity exec-path ":"))
+    (setq response-str (lspce-module-connect root-uri lsp-type server-cmd server-args (json-encode (lspce--make-request "initialize" initialize-params lspce--latest-tick)) lspce-connect-server-timeout (mapconcat 'identity exec-path ":")) )
     (lspce--debug "lspce--connect response: %s" response-str)
 
     response-str))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ impl LspServer {
         cmd: String,
         cmd_args: String,
         initialize_req: String,
+        emacs_exec_path: String,
     ) -> Option<LspServer> {
         let args = cmd_args.split_ascii_whitespace().collect::<Vec<&str>>();
 
@@ -150,6 +151,7 @@ impl LspServer {
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
+            .env("PATH", emacs_exec_path)
             .spawn();
 
         if let Ok(mut c) = child {
@@ -484,6 +486,7 @@ fn connect(
     cmd_args: String,
     initialize_req: String,
     timeout: i32,
+    emacs_exec_path: String,
 ) -> Result<Option<String>> {
     Logger::info(&format!(
         "start initializing server for lsp_type {} in project {}",
@@ -508,6 +511,7 @@ fn connect(
         cmd.clone(),
         cmd_args.clone(),
         initialize_req.clone(),
+        emacs_exec_path.clone(),
     );
     if let Some(mut s) = server {
         let server_info: LspServerInfo;


### PR DESCRIPTION
I have been using `direnv` to manage my development environment and I'd like to switch to `lspce` from `eglot`. However, when spawning the LSP server, it ignores the `PATH` that `direnv` provides, preventing me from accessing the proper development environment, like `python virtualenv`.

I made a few changes to `lspce.el` to make it pass the `exec-path` when spawning the LSP server. It's now working, but I'm not sure if this is the correct approach. Do you have any suggestions?
