### PR TITLE
Issue a comprehensible error when JSON support in Emacs is missing

### DIFF
--- a/lspce.el
+++ b/lspce.el
@@ -22,6 +22,10 @@
 (require 'lspce-structs)
 (require 'lspce-snippet)
 
+
+(unless (json-available-p)
+  (user-error "LSPCE needs JSON support in Emacs; please rebuild it using `--with-json'"))
+
 ;;; User tweakable stuff
 (defgroup lspce nil
   "Interaction with Language Server Protocol servers"


### PR DESCRIPTION
Currently, if Emacs is compiled without JSON support, LSPCE dies with random errors about unknown `json-*` functions, which is not user-friendly at all.