### PR TITLE
fixed cargo clippy warnings and format

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -38,17 +38,16 @@ impl Connection {
     }
 
     pub fn read(&self) -> Option<Message> {
-        let msg = match self.receiver.recv_timeout(std::time::Duration::from_millis(1)) {
-            Ok(q) => {
-                Some(q)
-            }
+        match self
+            .receiver
+            .recv_timeout(std::time::Duration::from_millis(1))
+        {
+            Ok(q) => Some(q),
             Err(e) => {
                 // Logger::error(&format!("Connection read error {}", e));
                 None
             }
-        };
-
-        msg
+        }
     }
 
     pub fn to_exit(&self) {
@@ -70,8 +69,7 @@ impl Connection {
         let exit = Arc::new(Mutex::new(false));
 
         let exit2 = Arc::clone(&exit);
-        let (sender, receiver, io_threads) =
-            stdio::stdio_transport(stdin, stdout, exit2);
+        let (sender, receiver, io_threads) = stdio::stdio_transport(stdin, stdout, exit2);
         (
             Connection {
                 sender,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,14 @@ use connection::Connection;
 use crossbeam_channel::SendError;
 use emacs::{defun, Env, IntoLisp, Result, Value};
 use error::LspceError;
+use logger::Logger;
 use logger::LOG_DEBUG;
 use logger::LOG_DISABLED;
-use logger::LOG_LEVEL;
-use logger::Logger;
 use logger::LOG_FILE_NAME;
+use logger::LOG_LEVEL;
 
-use lsp_types::DidChangeTextDocumentParams;
 use lsp_types::Diagnostic;
+use lsp_types::DidChangeTextDocumentParams;
 use lsp_types::InitializeParams;
 use lsp_types::InitializeResult;
 use lsp_types::InitializedParams;
@@ -163,7 +163,7 @@ impl LspServer {
             server_info.id = c.id().to_string();
             let mut server = LspServer {
                 child: Some(c),
-                server_info: server_info,
+                server_info,
                 status: SERVER_STATUS_STARTING,
                 transport: Arc::new(Mutex::new(Some(transport))),
                 transport_threads: Some(transport_threads),
@@ -223,16 +223,25 @@ impl LspServer {
                         let request_tick = server_data.request_ticks.get(&id);
                         if (request_tick.is_some()) {
                             let request_tick = request_tick.unwrap().clone();
-                            Logger::debug(&format!("Request tick for id {} is {}", &id, &request_tick));
+                            Logger::debug(&format!(
+                                "Request tick for id {} is {}",
+                                &id, &request_tick
+                            ));
                             if (request_tick.eq(&server_data.latest_request_tick)) {
                                 r.request_tick = request_tick.clone();
                                 server_data.responses.push_back(r);
                             }
-                            Logger::debug(&format!("Latest response id is {}, current response id {}", &server_data.latest_response_id, &id));
+                            Logger::debug(&format!(
+                                "Latest response id is {}, current response id {}",
+                                &server_data.latest_response_id, &id
+                            ));
                             if server_data.latest_response_id.lt(&id) {
                                 server_data.latest_response_id = id.clone();
                                 server_data.latest_response_tick = request_tick.clone();
-                                Logger::debug(&format!("Change Latest response tick for id {} to {}", &server_data.latest_response_id, &request_tick));
+                                Logger::debug(&format!(
+                                    "Change Latest response tick for id {} to {}",
+                                    &server_data.latest_response_id, &request_tick
+                                ));
                             }
 
                             server_data.request_ticks.remove(&id);
@@ -248,21 +257,20 @@ impl LspServer {
                         if r.method.eq("textDocument/publishDiagnostics") {
                             let mut params =
                                 serde_json::from_value::<PublishDiagnosticsParams>(r.params)
-                                .unwrap();
+                                    .unwrap();
 
                             let uri = params.uri.as_str().to_string();
                             let mut file_info = FileInfo::new(uri.clone());
                             // cache no more than MAX_DIAGNOSTICS_COUNT diagnostics
-                            let max_diagnostic_count = MAX_DIAGNOSTICS_COUNT.load(Ordering::Relaxed);
+                            let max_diagnostic_count =
+                                MAX_DIAGNOSTICS_COUNT.load(Ordering::Relaxed);
                             if max_diagnostic_count < 0 {
                                 file_info.diagnostics = params.diagnostics;
+                            } else if params.diagnostics.len() > max_diagnostic_count as usize {
+                                params.diagnostics.truncate(max_diagnostic_count as usize);
+                                file_info.diagnostics = params.diagnostics;
                             } else {
-                                if params.diagnostics.len() > max_diagnostic_count as usize {
-                                    params.diagnostics.truncate(max_diagnostic_count as usize);
-                                    file_info.diagnostics = params.diagnostics;
-                                } else {
-                                    file_info.diagnostics = params.diagnostics;
-                                }
+                                file_info.diagnostics = params.diagnostics;
                             }
 
                             let mut server_data = server_data.lock().unwrap();
@@ -282,7 +290,7 @@ impl LspServer {
             }
         });
 
-        return handle;
+        handle
     }
 
     pub fn stop_dispatcher(&mut self) {
@@ -394,7 +402,7 @@ impl LspServer {
 }
 
 struct Project {
-    pub root_uri: String,                    // 
+    pub root_uri: String,                    //
     pub servers: HashMap<String, LspServer>, // map each language_id to a lsp server
 }
 
@@ -420,16 +428,15 @@ fn init(env: &Env) -> Result<Value<'_>> {
 fn change_max_diagnostics_count(env: &Env, count: i32) -> Result<Value<'_>> {
     MAX_DIAGNOSTICS_COUNT.store(count, Ordering::Relaxed);
 
-    env.message(&format!("max diagnostics changed to {}!", count))
+    env.message(format!("max diagnostics changed to {}!", count))
 }
 
 #[defun]
 fn read_max_diagnostics_count(env: &Env) -> Result<i32> {
     let count = MAX_DIAGNOSTICS_COUNT.load(Ordering::Relaxed);
 
-    return Ok(count);
+    Ok(count)
 }
-
 
 /// disable logging to /tmp/lspce.log
 #[defun]
@@ -451,7 +458,7 @@ fn enable_logging(env: &Env) -> Result<Value<'_>> {
 fn set_log_level(env: &Env, level: u8) -> Result<Value<'_>> {
     LOG_LEVEL.store(level, Ordering::Relaxed);
 
-    env.message(&format!("log level set to {}!", level))
+    env.message(format!("log level set to {}!", level))
 }
 
 /// set logging file name
@@ -459,7 +466,7 @@ fn set_log_level(env: &Env, level: u8) -> Result<Value<'_>> {
 fn set_log_file(env: &Env, file: String) -> Result<Value<'_>> {
     *LOG_FILE_NAME.lock().unwrap() = file.clone();
 
-    env.message(&format!("Set logging file to {}", file))
+    env.message(format!("Set logging file to {}", file))
 }
 
 fn projects() -> &'static Arc<Mutex<HashMap<String, Project>>> {
@@ -535,11 +542,20 @@ fn connect(
             }
         }
 
-        Logger::info(&format!("Connected to server successfully. server capabilities {}", &server_info.capabilities));
-        return Ok(Some(serde_json::to_string(&server_info).unwrap()));
+        Logger::info(&format!(
+            "Connected to server successfully. server capabilities {}",
+            &server_info.capabilities
+        ));
+        Ok(Some(serde_json::to_string(&server_info).unwrap()))
     } else {
-        Logger::error(&format!("Failed to connect to server {}, {} for project {} {}.", cmd.clone(), cmd_args.clone(), root_uri.clone(), lsp_type.clone()));
-        return Ok(None);
+        Logger::error(&format!(
+            "Failed to connect to server {}, {} for project {} {}.",
+            cmd.clone(),
+            cmd_args.clone(),
+            root_uri.clone(),
+            lsp_type.clone()
+        ));
+        Ok(None)
     }
 }
 
@@ -605,7 +621,7 @@ fn initialize(
         if timeout > 0
             && Instant::now().duration_since(start_time).as_millis() > timeout as u128 * 1000
         {
-            Logger::error(&format!("timeout when initializing server."));
+            Logger::error("timeout when initializing server.");
 
             return false;
         }
@@ -621,19 +637,22 @@ fn shutdown(env: &Env, root_uri: String, file_type: String, req: String) -> Resu
             thread::spawn(move || {
                 let server_name = server.server_info.name.clone();
                 let server_id = server.server_info.id.clone();
-                Logger::info(&format!("start to shut down server {}, server_id {}", &server_name, &server_id));
+                Logger::info(&format!(
+                    "start to shut down server {}, server_id {}",
+                    &server_name, &server_id
+                ));
 
                 let msg = serde_json::from_str::<Request>(&req);
                 if msg.is_err() {
                     Logger::error(&format!("request is not valid json {}", &req));
-                    return ();
+                    return;
                 }
 
                 let msg = msg.unwrap();
                 let id = msg.id.clone();
 
                 if !_request_async(&mut server, msg) {
-                    return ();
+                    return;
                 }
 
                 let start_time = Instant::now();
@@ -649,15 +668,24 @@ fn shutdown(env: &Env, root_uri: String, file_type: String, req: String) -> Resu
 
                                 server.stop_dispatcher();
                                 server.exit_transport();
-                                Logger::info(&format!("after exit transport for server {}, server_id {}.", &server_name, &server_id));
+                                Logger::info(&format!(
+                                    "after exit transport for server {}, server_id {}.",
+                                    &server_name, &server_id
+                                ));
                                 // waiting for transport_threads to exit
                                 server.transport_threads.take().unwrap().join();
-                                Logger::info(&format!("after thread join for server {}, server_id {}.", &server_name, &server_id));
+                                Logger::info(&format!(
+                                    "after thread join for server {}, server_id {}.",
+                                    &server_name, &server_id
+                                ));
                                 // waiting for child to exit
                                 server.child.take().unwrap().wait();
-                                Logger::info(&format!("after child wait for server {}, server_id {}.", &server_name, &server_id));
+                                Logger::info(&format!(
+                                    "after child wait for server {}, server_id {}.",
+                                    &server_name, &server_id
+                                ));
 
-                                return ();
+                                return;
                             }
                         }
                         None => {
@@ -670,10 +698,9 @@ fn shutdown(env: &Env, root_uri: String, file_type: String, req: String) -> Resu
                         server.exit_transport();
                         server.kill_child();
 
-                        return ();
+                        return;
                     }
                 }
-                
             });
         } else {
             env.message(&format!("No server for {}", &file_type));
@@ -709,21 +736,20 @@ fn _request_async(server: &mut LspServer, req: Request) -> bool {
 
     server.update_request_info(id.clone(), request_tick);
 
-    if method == "textDocument/didChange" || method == "textDocument/didClose"{
+    if method == "textDocument/didChange" || method == "textDocument/didClose" {
         let param = serde_json::from_value::<DidChangeTextDocumentParams>(req.params.clone());
         if let Ok(param) = param {
-            server.clear_diagnostics(&param.text_document.uri.to_string());
+            server.clear_diagnostics(param.text_document.uri.as_ref());
         }
     }
-    
 
     let write_result = server.write(Message::Request(req));
     match write_result {
-        Ok(_) => return true,
+        Ok(_) => true,
         Err(e) => {
             Logger::error(&format!("request error {:#?}", e));
 
-            return false;
+            false
         }
     }
 }
@@ -756,19 +782,19 @@ fn request_async(
             }
 
             if _request_async(server, msg) {
-                return Ok(Some(true));
+                Ok(Some(true))
             } else {
-                return Ok(None);
+                Ok(None)
             }
         } else {
             env.message(&format!("No server for {}", &file_type));
 
-            return Ok(None);
+            Ok(None)
         }
     } else {
         env.message(&format!("No project for {} {}", &root_uri, &file_type));
 
-        return Ok(None);
+        Ok(None)
     }
 }
 
@@ -785,7 +811,7 @@ fn _notify(server: &mut LspServer, req: Notification) -> Result<Option<bool>> {
         }
     }
 
-    return Ok(None);
+    Ok(None)
 }
 
 #[defun]
@@ -794,7 +820,7 @@ fn notify(env: &Env, root_uri: String, file_type: String, req: String) -> Result
     if let Some(mut p) = projects.get_mut(&root_uri) {
         if let Some(mut server) = p.servers.get_mut(&file_type) {
             if server.status != SERVER_STATUS_RUNNING {
-                env.message(&format!("Server is not ready."));
+                env.message("Server is not ready.");
                 return Ok(None);
             }
             Logger::trace(&format!("notify {}", &req));
@@ -815,7 +841,7 @@ fn notify(env: &Env, root_uri: String, file_type: String, req: String) -> Result
         env.message(&format!("No project for {} {}", &root_uri, &file_type));
     }
 
-    return Ok(None);
+    Ok(None)
 }
 
 /// precondition: have called read_latest_response_id and gotten the id.
@@ -852,11 +878,7 @@ fn read_response_exact(
 }
 
 #[defun]
-fn read_notification(
-    env: &Env,
-    root_uri: String,
-    file_type: String,
-) -> Result<Option<String>> {
+fn read_notification(env: &Env, root_uri: String, file_type: String) -> Result<Option<String>> {
     let projects = projects().lock().unwrap();
     if let Some(p) = projects.get(&root_uri) {
         if let Some(server) = p.servers.get(&file_type) {
@@ -879,7 +901,6 @@ fn read_notification(
     Ok(None)
 }
 
-
 #[defun]
 fn read_file_diagnostics(
     env: &Env,
@@ -894,8 +915,8 @@ fn read_file_diagnostics(
             if let Some(file_info) = server_data.file_infos.get_mut(&uri) {
                 let result = serde_json::to_string(&file_info.diagnostics);
 
-                if result.is_ok() {
-                    return Ok(Some(result.unwrap()));
+                if let Ok(result) = result {
+                    return Ok(Some(result));
                 }
             }
         } else {
@@ -951,4 +972,3 @@ fn read_latest_response_tick(
 
     Ok(None)
 }
-

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -45,7 +45,7 @@ impl Logger {
                 .as_bytes(),
         );
         logger.write_all(buf.as_bytes());
-        logger.write("\n".as_bytes());
+        logger.write_all("\n".as_bytes());
     }
     pub fn error(buf: &str) {
         let log_level = LOG_LEVEL.load(Ordering::Relaxed);
@@ -90,7 +90,7 @@ fn logger() -> &'static Arc<Mutex<dyn Write>> {
 
     ONCE.call_once(|| unsafe {
         let file_name = log_file_name();
-        if file_name.len() > 0 {
+        if !file_name.is_empty() {
             if let Ok(f) = File::options().create(true).append(true).open(file_name) {
                 LOGGER.as_mut_ptr().write(Arc::new(Mutex::new(f)))
             } else {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -122,7 +122,7 @@ pub enum ErrorCode {
     /// Error code indicating that a server received a notification or
     /// request before the server has received the `initialize` request.
     ServerNotInitialized = -32002,
-    UnknownErrorCode = -32001,
+    UnknownError = -32001,
 
     // Defined by the protocol:
     /// The client has canceled a request and a server has detected
@@ -171,15 +171,15 @@ impl Message {
         match msg {
             Message::Request(mut r) => {
                 r.content = text;
-                return Ok(Some(Message::Request(r)));
+                Ok(Some(Message::Request(r)))
             }
             Message::Response(mut r) => {
                 r.content = text;
-                return Ok(Some(Message::Response(r)));
+                Ok(Some(Message::Response(r)))
             }
             Message::Notification(mut r) => {
                 r.content = text;
-                return Ok(Some(Message::Notification(r)));
+                Ok(Some(Message::Notification(r)))
             }
         }
     }
@@ -332,7 +332,7 @@ fn read_msg_text(inp: &mut dyn BufRead) -> io::Result<Option<String>> {
 }
 
 fn write_msg_text(out: &mut dyn Write, msg: &str) -> io::Result<()> {
-    out.write_all(&format!("Content-Length: {}\r\n\r\n{}", msg.len(), &msg).as_bytes())?;
+    out.write_all(format!("Content-Length: {}\r\n\r\n{}", msg.len(), &msg).as_bytes())?;
     out.flush()?;
 
     Ok(())

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -20,8 +20,7 @@ pub(crate) fn socket_transport(
     exit: Arc<Mutex<bool>>,
 ) -> (Sender<Message>, Receiver<Message>, IoThreads) {
     let exit_reader = Arc::clone(&exit);
-    let (reader_receiver, reader) =
-        make_reader(stream.try_clone().unwrap(), exit_reader);
+    let (reader_receiver, reader) = make_reader(stream.try_clone().unwrap(), exit_reader);
 
     let exit_writer = Arc::clone(&exit);
     let (writer_sender, writer) = make_writer(stream.try_clone().unwrap(), exit_writer);

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -12,7 +12,7 @@ use bytes::BytesMut;
 use crossbeam_channel::{bounded, Receiver, Sender};
 
 use crate::logger::{log_enabled, LOG_DEBUG};
-use crate::msg::{Message, Response, RequestId, ErrorCode};
+use crate::msg::{ErrorCode, Message, RequestId, Response};
 use crate::{
     connection::{NOTIFICATION_MAX, REQUEST_MAX},
     logger::Logger,
@@ -33,7 +33,7 @@ pub(crate) fn stdio_transport(
                 match exit_writer.lock() {
                     Ok(exit) => {
                         if *exit {
-                            Logger::info(&format!("stdio writer_thread exited"));
+                            Logger::info("stdio writer_thread exited");
                             break;
                         }
                     }
@@ -55,7 +55,7 @@ pub(crate) fn stdio_transport(
                 Err(t) => Ok(()),
             };
         }
-        Logger::info(&format!("stdio writer_thread exited normally."));
+        Logger::info("stdio writer_thread exited normally.");
         Ok(())
     });
 
@@ -70,7 +70,7 @@ pub(crate) fn stdio_transport(
                 match exit_reader.lock() {
                     Ok(exit) => {
                         if *exit {
-                            Logger::info(&format!("stdio reader_thread exited"));
+                            Logger::info("stdio reader_thread exited");
                             break;
                         }
                     }
@@ -85,15 +85,18 @@ pub(crate) fn stdio_transport(
                         if log_enabled(LOG_DEBUG) {
                             let msg_log = msg.clone();
                             match msg_log {
-                                Message::Request(r) => {
-                                    Logger::debug(&format!("stdio read request {}", serde_json::to_string_pretty(&r).unwrap_or(r.content)))
-                                }
-                                Message::Response(r) => {
-                                    Logger::debug(&format!("stdio read response {}", serde_json::to_string_pretty(&r).unwrap_or(r.content)))
-                                }
-                                Message::Notification(r) => {
-                                    Logger::debug(&format!("stdio read notification {}", serde_json::to_string_pretty(&r).unwrap_or(r.content)))
-                                }
+                                Message::Request(r) => Logger::debug(&format!(
+                                    "stdio read request {}",
+                                    serde_json::to_string_pretty(&r).unwrap_or(r.content)
+                                )),
+                                Message::Response(r) => Logger::debug(&format!(
+                                    "stdio read response {}",
+                                    serde_json::to_string_pretty(&r).unwrap_or(r.content)
+                                )),
+                                Message::Notification(r) => Logger::debug(&format!(
+                                    "stdio read notification {}",
+                                    serde_json::to_string_pretty(&r).unwrap_or(r.content)
+                                )),
                             }
                         }
                         let r = sender_to_client.send(msg);
@@ -113,10 +116,13 @@ pub(crate) fn stdio_transport(
             }
         }
 
-        Logger::info(&format!("stdio reader_thread exited."));
+        Logger::info("stdio reader_thread exited.");
         Ok(())
     });
-    let threads = IoThreads { reader: reader_thread, writer: writer_thread };
+    let threads = IoThreads {
+        reader: reader_thread,
+        writer: writer_thread,
+    };
     (sender_for_client, receiver_for_client, threads)
 }
 


### PR DESCRIPTION
I ran `cargo fmt` because the formatting was off.
I also fixed some warnings that `cargo clippy` was showing.