### PR TITLE
support workspace/applyEdit

### DIFF
--- a/lspce-types.el
+++ b/lspce-types.el
@@ -36,7 +36,7 @@
 (defun lspce--clientCapabilities ()
   (list
    :workspace (list
-               :applyEdit :json-false
+               :applyEdit t
                :executeCommand (list
                                 :dynamicRegistration :json-false)
                :workspaceEdit (list

--- a/lspce.el
+++ b/lspce.el
@@ -873,8 +873,8 @@ The value is also a hash table, with uri as the key and the value is just t.")
         (setq-local lspce--lsp-type nil)
         (setq-local lspce--recent-changes nil
                     lspce--identifier-version 0
-                    lspce--uri nil))))
-  )
+                    lspce--uri nil)))))
+  
 
 (defun lspce--server-id (&optional buffer)
   (with-current-buffer (or buffer (current-buffer))
@@ -895,6 +895,7 @@ The value is also a hash table, with uri as the key and the value is just t.")
   "Whether eldoc is enabled before lspce starting.")
 
 (defvar lspce--notification-idle-timer nil)
+(defvar lspce--request-idle-timer nil)
 
 ;;;###autoload
 (defun lspce-enable-notification-handler ()
@@ -909,6 +910,31 @@ The value is also a hash table, with uri as the key and the value is just t.")
   (interactive)
   (when lspce--notification-idle-timer
     (cancel-timer lspce--notification-idle-timer)))
+
+;;;###autoload
+(defun lspce-enable-request-handler ()
+  (interactive)
+  (when lspce--request-idle-timer
+    (cancel-timer lspce--request-idle-timer))
+  (setq lspce--request-idle-timer
+        (run-with-idle-timer 0.01 t #'lspce--request-handler)))
+
+;;;###autoload
+(defun lspce-disable-request-handler ()
+  (interactive)
+  (when lspce--request-idle-timer
+    (cancel-timer lspce--request-idle-timer)))
+
+(defun lspce--request-handler ()
+  (with-current-buffer (current-buffer)
+    (when (and lspce-mode
+               lspce--root-uri
+               lspce--lsp-type)
+      (when-let* ((request (lspce-module-read-request lspce--root-uri lspce--lsp-type))
+                  (request (lspce--json-deserialize request))
+                  (method (gethash "method" request)))
+        (when (string-equal method "workspace/applyEdit")
+          (lspce--apply-workspace-edit (gethash "edit" (gethash "params" request))))))))
 
 (defun lspce--notification-handler ()
   (let (notification
@@ -940,8 +966,8 @@ The value is also a hash table, with uri as the key and the value is just t.")
               (lspce--info "Server message: %s" message))
              ((eq message-type 4)
               (lspce--debug "Server message: %s" message))))
-           (t
-            )))))))
+           (t)))))))
+            
 
 (defun lspce--remove-overlays ()
   (remove-overlays nil nil 'lspce--overlay t))
@@ -1125,8 +1151,8 @@ The value is also a hash table, with uri as the key and the value is just t.")
                   (paddingRight (gethash "paddingRight" hint))
                   (hint-after-p (eql kind 1))
                   (hint-point (lspce--lsp-position-to-point pos))
-                  (left-pad )
-                  (right-pad )
+                  (left-pad)
+                  (right-pad)
                   ov text)
              (when (and (>= hint-point start) (<= hint-point end))
                (goto-char hint-point)
@@ -1321,8 +1347,8 @@ If optional MARKERS, make markers."
               end-line end-column items xref-items groups)
     (cond
      ((arrayp locations)
-      (setq items locations)
-      )
+      (setq items locations))
+      
      ((hash-table-p locations)
       (setq items (list locations)))
      ((listp locations)
@@ -1476,9 +1502,9 @@ IDENTIFIER can be any string returned by
 `xref-backend-identifier-at-point', or from the table returned by
 `xref-backend-identifier-completion-table'.
 
-To create an xref object, call `xref-make'.")
+To create an xref object, call `xref-make'."))
   
-  )
+  
 
 (cl-defmethod xref-backend-implementations
   ((_backend (eql xref-lspce)) identifier)
@@ -1513,8 +1539,8 @@ IDENTIFIER can be any string returned by
 `xref-backend-identifier-at-point', or from the table returned by
 `xref-backend-identifier-completion-table'.
 
-To create an xref object, call `xref-make'.")
-  )
+To create an xref object, call `xref-make'."))
+  
 
 (cl-defmethod xref-backend-type-definition
   ((_backend (eql xref-lspce)) identifier)
@@ -1553,8 +1579,8 @@ IDENTIFIER can be any string returned by
 `xref-backend-identifier-at-point', or from the table returned by
 `xref-backend-identifier-completion-table'.
 
-To create an xref object, call `xref-make'.")
-  )
+To create an xref object, call `xref-make'."))
+  
 
 (cl-defmethod xref-backend-declaration ((_backend (eql xref-lspce)) identifier)
   (when (lspce--server-capable "declarationProvider")
@@ -1687,7 +1713,7 @@ Doubles as an indicator of snippet support."
       (setq-local markdown-fontify-code-blocks-natively t)
       (insert string)
       (let ((inhibit-message t)
-	    (message-log-max nil))
+            (message-log-max nil))
         (ignore-errors (delay-mode-hooks (funcall mode))))
       (font-lock-ensure)
       (string-trim (buffer-string)))))
@@ -2048,13 +2074,13 @@ matches any of the TRIGGER-CHARACTERS."
               (setq content (concat content "\n" c)))
              ((hash-table-p c)
               (setq content (concat "```" (gethash "language" c) "\n" (gethash "value" c) "\n```")))
-             (t
-              )))
+             (t)))
+              
           (when (and kind content)
             (setq hover-info (list kind content))))
-         (t
+         (t)))
           ;; nothing
-          )))
+          
       hover-info)))
 
 (defun lspce--eldoc-render-markup (content)
@@ -2066,7 +2092,7 @@ matches any of the TRIGGER-CHARACTERS."
           (setq mode 'gfm-view-mode)
         (setq mode 'gfm-mode))
       (let ((inhibit-message t)
-	    (message-log-max nil))
+            (message-log-max nil))
         (ignore-errors (delay-mode-hooks (funcall mode))))
       (font-lock-ensure)
       (mapconcat #'identity (seq-filter (lambda (s) (not (string-match-p "^```" s)))


### PR DESCRIPTION
`workspace/applyEdit` is very useful in zig, because unused variables are a compile error and zls provides autofixes for this
```zig
const x = 1;
```
becomes
```zig
const x = 1;
_ = x;
```

This PR attempts to implement this, but I'm not sure:
1) is popping requests in an idle timer the best way to do this?
2) I still need to manually call `lspce-enable-request-handler`, how is this done for notifications?
3) don't know if we're supposed to save the file after applying the edit