### PR TITLE
fix(lspce): fixed wrong-type-argument overlayp error when removing flymake diagnostics on lspce-server-restart

### DIFF
--- a/lspce.el
+++ b/lspce.el
@@ -1951,7 +1951,12 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
     (when lspce-enable-flymake
       (if (not lspce--flymake-already-enabled)
           (flymake-mode -1)
-        (mapc #'delete-overlay (flymake-diagnostics))))
+        ;; Extract the overlay from each diagnostic before deletion
+        ;; This prevents "wrong-type-argument overlayp" errors
+        (mapc (lambda (diag)
+                (when-let ((overlay (flymake--diag-overlay diag)))
+                  (delete-overlay overlay)))
+              (flymake-diagnostics))))
     (when (and lspce-enable-eldoc
                (not lspce--eldoc-already-enabled))
       (eldoc-mode -1))


### PR DESCRIPTION
### Main issue
`Debugger entered--Lisp error: (wrong-type-argument overlayp #s(flymake--diag :locus #<buffer path/to/file.dart> :beg 1578 :end 1587 :type lspce-warning ...`
at point: https://github.com/zbelial/lspce/blob/ef16151491307a7965f40ad06e9a4fc2e664b1a3/lspce.el#L1954

### How to reproduce

1. Open file for the programming language you have the setup with `lspce`
2. Start `lspce-mode` in the current buffer
3. Make changes which will result in diagnostics in the current buffer (save the buffer?)
4. `M-x lspce-restart-server`
5. Error output in the `*Messages*` buffer

### Origin
As I understand, `delete-overlay` is expecting an overlay object as an argument, but in the current code it's being fed a list of diagnostic objects instead.

### Fix
1. processing all diagnostics objects from `(flymake-diagnostics)` with defined lambda to
2. extract the overlay first from the diagnostic object
3. then calling `delete-overlay` with the overlay object as an argument
```elisp
(mapc (lambda  (diag)
             (when-let ((overlay (flymake--diag-overlay diag)))
                 (delete-overlay overlay)))
             (flymake-diagnostics))
```

### Additional information
to test that `(flymake-diagnostics)` returns a list of diagnostics object with an overlay object in each of them.
```elisp
(defun test-flymake-diagnostics ()
  "Test and inspect flymake diagnostics structure."
  (interactive)
  (let ((diagnostics (flymake-diagnostics)))
    (if (null diagnostics)
        (message "No flymake diagnostics in current buffer.")
      (let* ((first-diag (car diagnostics))
             (diag-type (type-of first-diag))
             (has-overlay (and (fboundp 'flymake--diag-overlay) 
                              (flymake--diag-overlay first-diag))))
        (message "First diagnostic: %S" first-diag)
        (message "Type: %S" diag-type)
        (message "Has overlay method: %s" (fboundp 'flymake--diag-overlay))
        (message "Overlay: %S" has-overlay)
        (message "Is overlay: %s" (overlayp has-overlay))))))
```

I'm not sure how to properly organize the code here. It looks like it would be better to extract this to a separate function, but I don't know how you would prefer to organize it, so I'll leave that decision to you.