### PR TITLE
fix: show initial diagnostics on open

### DIFF
--- a/README.org
+++ b/README.org
@@ -127,7 +127,7 @@
   | lspce-enable-logging                             | nil            | If non-nil, enable logging to file.                                                                 |
   | lspce-auto-enable-within-project                 | t              | If non-nil, enable lspce when a file is opened if lspce has already been enabled in current project |
   | lspce-after-text-edit-hook                       | nil            | Functions called after finishing all text edits in a buffer.                                        |
-  | lspce-afte-each-text-edit-hook                   | nil            | Functions called after finishing each text edit in a buffer.                                        |
+  | lspce-after-each-text-edit-hook                  | nil            | Functions called after finishing each text edit in a buffer.                                        |
   | lspce-show-log-level-in-modeline                 | t              | If non-nil, show log level in modeline.                                                             |
   | lspce-inherit-exec-path                          | nil            | If non-nil, pass `exec-path' as PATH to rust code to create the lsp subprocess.                     |
   | MAX_DIAGNOSTIC_COUNT                             | 30             | How many diagnostics should be retrieved.                                                           |

--- a/lspce.el
+++ b/lspce.el
@@ -1914,6 +1914,8 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
           (setq-local lspce--flymake-already-enabled t))
         (lspce--save-and-rebind flymake-diagnostic-functions
                                 '(lspce-flymake-backend))
+        ;; postpone flymake check since there is no diagnostic yet
+        (setq-local flymake-start-on-flymake-mode nil)
         (flymake-mode 1))
       (when lspce-enable-imenu-index-function
         (lspce--save-and-rebind imenu-create-index-function
@@ -1928,7 +1930,13 @@ Records BEG, END and PRE-CHANGE-LENGTH locally."
               (lspce-mode -1)))
         ((error user-error quit)
          (lspce--error "lspce-mode enable: error [%s]" err)
-         (lspce-mode -1))))))
+         (lspce-mode -1)))
+
+      (when lspce-enable-flymake
+        ;; if diagnostics configured, then server will send `publishDiagnostics'
+        ;; notification after receiving a `didOpen' one. So, wait a bit more to
+        ;; let it arrive and be checked synchroniously by flymake. 
+        (run-with-timer lspce-idle-delay nil #'flymake-start t)))))
    (t
     (remove-hook 'after-change-functions 'lspce--after-change t)
     (remove-hook 'before-change-functions 'lspce--before-change t)


### PR DESCRIPTION
Postpone flymake-start a bit till initial diagnostic is available.

Lspce uses flymake to show diagnostics (from textDocument/publishDiagnostic), which query lspce-(rust)-module for diagnostics synchronously (due to buffer changes+idle timeout+timer). Note that diagnostic notifications and messages arrives to rust module asynchronously.

According to LSP proto spec `publishDIagnositic` notification and relevant data will be sent right after `didOpen`, but lspce will show it **only after** the first change will be introduced in the buffer. To show this initial diagnostic which is already available after `didOpen`, there is a need to trigger flymake backend check or postpone `flymake-start` till initial diagnostic is available.

This patch introduces the following:
- avoid running `flymake-start` on `flymake-mode`
- run `flymake-start` after lspce connected to the server with slight delay
