### PR TITLE
Allow for customizing the [lspce] header in eldoc

### DIFF
--- a/lspce.el
+++ b/lspce.el
@@ -64,6 +64,11 @@
   :group 'lspce
   :type 'boolean)
 
+(defcustom lspce-eldoc-display-backend "[lspce]"
+  "If non-nil, display this variable above the documentation as a header"
+  :group 'lspce
+  :type '(choice string (const nil)))
+
 (defcustom lspce-enable-flymake t
   "If non-nil, enable flymake."
   :group 'lspce
@@ -1267,7 +1272,8 @@ matches any of the TRIGGER-CHARACTERS."
        ((or signature content)
         (setq document (concat signature content))))
       (when document
-        (setq backend (propertize "[lspce]\n" 'face 'lspce-eldoc-backend-face))
+        (when lspce-eldoc-display-backend
+          (setq backend (propertize (concat lspce-eldoc-display-backend "\n") 'face 'lspce-eldoc-backend-face)))
         (funcall callback (concat backend document))))))
 
 ;;; diagnostics


### PR DESCRIPTION
My usecase is that I use `eglot-eldoc-box` which displays the eldoc buffer on demand. I don't really use eldoc otherwise, but even then, my biggest use is having the eldoc show me the signature in message buffer, which it does by displaying the first line of the eldoc buffer.

The problem is that lspce shows `[lspce]` in the first line and there is no easy way to disable it.

My solution is to create a new variable that allows for customizing this header to either be any string (setting `[lspce]` as the default value) or `nil`. In that case the header is hidden completely.